### PR TITLE
Tighten up timings

### DIFF
--- a/rawirdecode/rawirdecode.ino
+++ b/rawirdecode/rawirdecode.ino
@@ -57,7 +57,7 @@ bool decodeZHLT01remote(byte *bytes, int byteCount);
 // what our timing resolution should be, larger is better
 // as its more 'precise' - but too large and you wont get
 // accurate timing
-uint16_t RESOLUTION=20;
+uint16_t RESOLUTION=5;
 
 // The thresholds for different symbols
 uint16_t MARK_THRESHOLD_BIT_HEADER    = 0; // Value between BIT MARK and HEADER MARK
@@ -205,9 +205,13 @@ void receivePulses(void) {
   space_pause_avg = 0;
   space_pause_cnt = 0;
 
+  unsigned long start = micros();
+  unsigned long last = start;
+
   while (currentpulse < sizeof(symbols))
   {
      highpulse = 0;
+     
      while (getPinState()) {
        // pin is still HIGH
 
@@ -223,7 +227,10 @@ void receivePulses(void) {
        }
     }
 
-    highpulse = highpulse * RESOLUTION;
+    // Instructions below here also take time, and need to be counted before the next high pulse.
+    unsigned long ts = micros();
+    highpulse = ts - last;
+    last = ts;
 
     if (currentpulse > 0)
     {
@@ -259,7 +266,9 @@ void receivePulses(void) {
 
     // this is a MARK
 
-    lowpulse = lowpulse * RESOLUTION;
+    ts = micros();
+    lowpulse = ts - last;
+    last = ts;
 
     if ( lowpulse > MARK_THRESHOLD_BIT_HEADER ) {
       symbols[currentpulse] = 'H';

--- a/rawirdecode/rawirdecode.ino
+++ b/rawirdecode/rawirdecode.ino
@@ -242,7 +242,8 @@ void receivePulses(void) {
       } else if ( (currentpulse > 0 && symbols[currentpulse-1] == 'H') || highpulse > SPACE_THRESHOLD_ONE_HEADER ) {
         symbols[currentpulse] = 'h';
         // Cumulative moving average, see http://en.wikipedia.org/wiki/Moving_average#Cumulative_moving_average
-        space_header_avg = (highpulse + space_header_cnt * space_header_avg) / ++space_header_cnt;
+        if (highpulse > SPACE_THRESHOLD_ONE_HEADER)
+          space_header_avg = (highpulse + space_header_cnt * space_header_avg) / ++space_header_cnt;
       } else if ( highpulse > SPACE_THRESHOLD_ZERO_ONE ) {
         symbols[currentpulse] = '1';
         space_one_avg = (highpulse + space_one_cnt * space_one_avg) / ++space_one_cnt;


### PR DESCRIPTION
This change adds support for cumulative timing of high/low sequences. By doing this I am able to improve the accuracy of timing measured while also reducing the resolution. With this I was able to greatly clean up some of the samples for my IR device, such that header bits are coming up as expected, and timings are more precise overall.

Here's a sample of data **prior** to this change. Sometimes it would come up as 161 - 163 symbols, failing maybe 20% of the time.

```
Number of symbols: 161
Symbols:
Hh00110000111000000000011000001010010W00000000001000100000000000001000WHh00110000111000000000011000001110010W00000000000000000000000000001011hHh1110100010100101

...

Timings (in us): 
PAUSE SPACE:  27340
HEADER MARK:  8220
HEADER SPACE: 5102
BIT MARK:     629
ZERO SPACE:   460
ONE SPACE:    1598
Decoding known protocols...
Looks like a Gree YAC protocol
```

with the change timings are generally always correct, here is the improved sample

```
Number of symbols: 161
Symbols:
Hh00110000111000000000011000001010010W00000000001000100000000000001000WHh00110000111000000000011000001110010W000000000000000000000000000010111Hh1110100010100101

...

Timings (in us): 
PAUSE SPACE:  26556
HEADER MARK:  8074
HEADER SPACE: 3905
BIT MARK:     713
ZERO SPACE:   447
ONE SPACE:    1600
Decoding known protocols...
Looks like a Gree YAC protocol
```

Subsequent timing data from repeated commands shows less devices, the next sample with new timing:

```
Timings (in us): 
PAUSE SPACE:  26624
HEADER MARK:  9004
HEADER SPACE: 4476
BIT MARK:     645
ZERO SPACE:   531
ONE SPACE:    1636
Decoding known protocols...
Looks like a Gree YAC protocol
```
