### PR TITLE
Add state of Gree I-FEEL to the GreeYAC decoder

### DIFF
--- a/rawirdecode/Gree_YAC.cpp
+++ b/rawirdecode/Gree_YAC.cpp
@@ -249,6 +249,15 @@ bool decodeGree_YAC(byte *bytes, int pulseCount)
 
 	}	
 
+	switch (bytes[5] & 0x4) {
+	case 0x00:
+		Serial.println(F("I-FEEL: OFF"));
+		break;
+	case 0x04:
+		Serial.println(F("I-FEEL: ON"));
+		break;
+	}
+
 	if (pulseCount == 161) {
 		Serial.print(F("I-Feel Temperature: "));
 		Serial.println(bytes[16]);
@@ -258,4 +267,3 @@ bool decodeGree_YAC(byte *bytes, int pulseCount)
 
   return false;
 }
-

--- a/rawirdecode/Gree_YAC.cpp
+++ b/rawirdecode/Gree_YAC.cpp
@@ -259,7 +259,7 @@ bool decodeGree_YAC(byte *bytes, int pulseCount)
 	}
 
 	if (pulseCount == 161) {
-		Serial.print(F("I-Feel Temperature: "));
+		Serial.print(F("I-FEEL TEMPERATURE: "));
 		Serial.println(bytes[16]);
 	}
     return true;


### PR DESCRIPTION
Simple change that also records the state of the I-FEEL function (on/off) in the GreeYAC decodes.

See this issue for more information on the bitfield layouts if required: https://github.com/ToniA/arduino-heatpumpir/issues/86#issuecomment-775624169

