### PR TITLE
Gree protocol checksum checking wrong byte

### DIFF
--- a/rawirdecode/Gree.cpp
+++ b/rawirdecode/Gree.cpp
@@ -17,7 +17,7 @@ bool decodeGree(byte *bytes, int pulseCount)
       ((bytes[7] & 0xF0) >> 4) +
       0x0A) & 0xF0;
 
-    if (checksum == bytes[8]) {
+    if (checksum == bytes[7]) {
       Serial.println(F("Checksum matches"));
     } else {
       Serial.println(F("Checksum does not match"));


### PR DESCRIPTION
Fixes a bug with checksum mismatch for simple Gree protocol. Should be checking byte 7, was checking byte 8 (71 symbols isn't enough for 8 bytes)