### PR TITLE
Addition of the Olimpia Splendid Maestro

### DIFF
--- a/rawirdecode/OlimpiaMaestro.cpp
+++ b/rawirdecode/OlimpiaMaestro.cpp
@@ -1,0 +1,106 @@
+#include <Arduino.h>
+
+// from Carrier.cpp
+#define BYTETOBINARYPATTERN "%d%d%d%d%d%d%d%d"
+#define BYTETOBINARY(byte)  \
+  (byte & 0x80 ? 1 : 0), \
+  (byte & 0x40 ? 1 : 0), \
+  (byte & 0x20 ? 1 : 0), \
+  (byte & 0x10 ? 1 : 0), \
+  (byte & 0x08 ? 1 : 0), \
+  (byte & 0x04 ? 1 : 0), \
+  (byte & 0x02 ? 1 : 0), \
+  (byte & 0x01 ? 1 : 0)
+
+bool decodeOlimpiaMaestro(byte *bytes, int byteCount)
+{
+  // If this looks like an Olimpia code...
+  if (byteCount == 11 && bytes[0] == 0x5A) {
+    Serial.println(F("Looks like an Olimpia-Splendid Maestro protocol"));
+
+    // Determine if the unit is off or in a specific mode (bits 8–10)
+    switch ((bytes[1] & 0x07)) {
+      case 0b001:
+        Serial.println(F("POWER ON"));
+        Serial.println(F("MODE COOL"));
+        break;
+      case 0b010:
+        Serial.println(F("POWER ON"));
+        Serial.println(F("MODE HEAT"));
+        break;
+      case 0b011:
+        Serial.println(F("POWER ON"));
+        Serial.println(F("MODE DRY"));
+        break;
+      case 0b100:
+        Serial.println(F("POWER ON"));
+        Serial.println(F("MODE FAN"));
+        break;
+      case 0b101:
+        Serial.println(F("POWER ON"));
+        Serial.println(F("MODE AUTO"));
+        break;
+      case 0b000:
+        Serial.println(F("POWER OFF"));
+        break;
+      default:
+        Serial.println(F("MODE UNKNOWN"));
+    }
+
+    // Temperature (bits 72–76)
+    Serial.print(F("Temperature: "));
+    if (bytes[9] & 0x20) {
+      uint8_t encodedTemp = ((bytes[9] & 0x1F));
+      Serial.print(((((float) encodedTemp) / 2) + 15) * (1.8) + 32);
+      Serial.println(F("°F"));
+    } else {
+      uint8_t encodedTemp = ((bytes[9] & 0x1F));
+      Serial.print((((float) encodedTemp) / 2) + 15);
+      Serial.println(F("°C"));
+    }
+
+    // Fan speed
+    switch ((bytes[1] & 0x18) >> 3) {
+      case 0b00:
+        Serial.println(F("FAN: LOW"));
+        break;
+      case 0b01:
+        Serial.println(F("FAN: MEDIUM"));
+        break;
+      case 0b10:
+        Serial.println(F("FAN: HIGH"));
+        break;
+      case 0b11:
+        Serial.println(F("FAN: AUTO"));
+        break;
+    }
+
+    // Other flags
+    Serial.print(F("FLAGS: "));
+    if (bytes[1] & 0x04) Serial.print(F("FLAP SWING "));
+    if (bytes[7] & 0x04) Serial.print(F("ECONO "));
+    if (bytes[1] & 0x02) Serial.print(F("LOW NOISE "));
+    Serial.println();
+
+    // Check if the checksum matches
+    byte checksum = 0x00;
+
+    for (int x = 0; x < 10; x++) {
+      checksum += bytes[x];
+    }
+
+    if ( bytes[10] == checksum ) {
+      Serial.println(F("Checksum matches"));
+    } else {
+      Serial.print(F("Checksum does not match.\nCalculated | Received\n  "));
+      Serial.printf(BYTETOBINARYPATTERN, BYTETOBINARY(checksum));
+      Serial.print(F(" | "));
+      Serial.printf(BYTETOBINARYPATTERN, BYTETOBINARY(bytes[10]));
+      Serial.println();
+    }
+
+    return true;
+  }
+
+  return false;
+}

--- a/rawirdecode/rawirdecode.ino
+++ b/rawirdecode/rawirdecode.ino
@@ -10,6 +10,7 @@
   #define PANASONIC_CKP
   #define PANASONIC_CS
   #define HYUNDAI
+  #define OLIMPIA // try model choice 3
   #define GREE
   #define GREE_YAC
   #define FUEGO
@@ -35,6 +36,7 @@
   //#define PANASONIC_CKP
   //#define PANASONIC_CS
   //#define HYUNDAI
+  //#define OLIMPIA
   //#define GREE
   //#define GREE_YAC
   //#define FUEGO
@@ -81,6 +83,9 @@
 #endif
 #if defined(HYUNDAI)
   bool decodeHyundai(byte *bytes, int pulseCount);
+#endif
+#if defined(OLIMPIA)
+  bool decodeOlimpiaMaestro(byte *bytes, int pulseCount);
 #endif
 #if defined(GREE) or defined(GREE_YAC)
   bool decodeGree(byte *bytes, int pulseCount);
@@ -149,7 +154,7 @@
 #elif defined(ESP32)
   #define IRpin          25 // G25 on M5STACK ATOM LITE
 #elif defined(ESP8266)
-  #define IRpin          5
+  #define IRpin          2
 #else
   #define IRpin_PIN      PIND
   #define IRpin          2
@@ -457,7 +462,7 @@ void printPulses(void) {
   // Print the decoded bytes
   Serial.println(F("Bytes:"));
 
-  // Decode the string of bits to a byte array
+  // Decode the string of bits to a byte array from LSB first to MSB last for each byte
   for (uint16_t i = 0; i < currentpulse; i++) {
 
     if (symbols[i] == '0' || symbols[i] == '1') {
@@ -568,6 +573,9 @@ void decodeProtocols()
 #endif
 #if defined(HYUNDAI)
   knownProtocol = decodeHyundai(bytes, currentpulse);
+#endif
+#if defined(OLIMPIA)
+  knownProtocol = decodeOlimpiaMaestro(bytes, byteCount);
 #endif
 #if defined(GREE) or defined(GREE_YAC)
   knownProtocol = decodeGree(bytes, currentpulse) || decodeGree_YAC(bytes, currentpulse);


### PR DESCRIPTION
Reverse engineered - can evaluate some of the captures here: https://gist.github.com/yincrash/4e687cbfda9d91f157eefe3b21966113

Product page:
https://olimpiasplendidusa.com/maestro-pro-inverter-12-hp

Changed the default ESP8266 pin to 2 (D4 on nodemcu-styleboards) Pin 5 is used for the i2c bus and can be occupied on boards with screens builtin.

Added an additional comment to describe that by default we're treating the bitstream as LSB to MSB byte ordering.